### PR TITLE
Update mrubyc to release3.4.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,15 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(OpenBlink)
 
+# Generate mrubyc autogen files
+add_custom_target(mrubyc_autogen
+    COMMAND make autogen
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/mrubyc
+    COMMENT "Generating mrubyc autogen files"
+)
+
+add_dependencies(app mrubyc_autogen)
+
 target_sources(app PRIVATE
                     src/main.c
                     src/app/blink.c

--- a/README.ja.md
+++ b/README.ja.md
@@ -126,6 +126,7 @@ OpenBlink をビルドする前に、以下の開発環境をセットアップ�
 - **nRF Connect SDK** v3.3.0 — [公式インストールガイド](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/installation/install_ncs.html) を参照
 - **nRF Connect SDK ツールチェーン** v3.3.0
 - **west**（nRF Connect SDK と一緒にインストールされます）
+- **Ruby**（mruby/cのautogenファイル生成に必要）
 
 ### リポジトリのクローン
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Before building OpenBlink, set up the following:
 - **nRF Connect SDK** v3.3.0 — see the [official installation guide](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/installation/install_ncs.html)
 - **nRF Connect SDK toolchain** v3.3.0
 - **west** (installed with the nRF Connect SDK)
+- **Ruby** (required for generating mruby/c autogen files)
 
 ### Clone the repository
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -126,6 +126,7 @@ OpenBlink 非常重视**在真实硬件上进行黑客创造的乐趣**。每一
 - **nRF Connect SDK** v3.3.0 — 请参阅 [官方安装指南](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/installation/install_ncs.html)
 - **nRF Connect SDK 工具链** v3.3.0
 - **west**（随 nRF Connect SDK 一同安装）
+- **Ruby**（生成 mruby/c autogen 文件所需）
 
 ### 克隆仓库
 


### PR DESCRIPTION
## Summary

This PR updates the mrubyc submodule from release3.4 to release3.4.1.

## Changes

- **mrubyc submodule**: Updated from release3.4 (commit 5d8147f) to release3.4.1 (commit 6782f50)
- **CMakeLists.txt**: Added autogen step to automatically generate mrubyc autogen files before build
- **Documentation**: Added Ruby to prerequisites in all README files (English, Japanese, Chinese)

## Background

mrubyc release3.4.1 includes important improvements and bug fixes, including:
- UTF-8 string support (disabled in this build to maintain compatibility)
- Unicode case mapping support
- Various bug fixes and performance improvements
- Enhanced autogen file generation process

The autogen step is required because mrubyc 3.4.1 generates certain header files (_autogen_*.h) that must be present before compilation. This change follows the pattern used in the openblink-webide repository.

## Build Verification

Both target boards have been successfully built and verified:

- **nRF52840-DK**: Build successful (FLASH: 314552 B, RAM: 107528 B)
- **nRF54L15-DK**: Build successful (FLASH: 313208 B, RAM: 105024 B)

## Prerequisites Update

Ruby is now listed as a prerequisite in all README files since it is required for generating mrubyc autogen files. Users building OpenBlink will need Ruby installed in their environment.

## Related

- Reference implementation in openblink-webide: https://github.com/OpenBlink/openblink-webide
- mrubyc release notes: https://github.com/mrubyc/mrubyc/releases/tag/release3.4.1